### PR TITLE
fixed race condition when creating table and indexes

### DIFF
--- a/object-storage-interface/main.ts
+++ b/object-storage-interface/main.ts
@@ -208,13 +208,17 @@ class ObjectClient {
 
   constructor(connStr: string) {
     this.db = new Database(connStr);
-    this.init();
   }
 
-  init() {
-    const { error, message } = initializeObjectsTable(this.db);
-    if (error) {
-      throw new Error(message);
+  async init() {
+    try {
+      const { error, message } = await initializeObjectsTable(this.db);
+      if (error) {
+        throw new Error(message);
+      }
+      console.log(message);
+    } catch (err) {
+      console.error(err);
     }
   }
 
@@ -247,6 +251,7 @@ const main = async () => {
     key: "FaceTime_User_Guide.pdf",
   });
 
+  await objectStorage.init()
   const putResponse = await objectStorage.send(putObject);
   console.log(putResponse);
   const getResponse = await objectStorage.send(getObject);

--- a/object-storage-interface/package.json
+++ b/object-storage-interface/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "objWrapper.js",
   "scripts": {
-    "start": "ts-node main.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "ts-node main.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Overview/Task

- [ x] Bug
- [] Feature

## Description
- Fixed race condition that was happening when the `objects` table and the indexes were created
- User has to call the `init` method to initialize the objects table

## Feature Validation/Bug Reproduction Steps
1. Create a `.env` file in the root directory and add your SQLite Cloud connection string
```bash
DB_CONNECTION_STRING="sqlitecloud://{HOST}.sqlite.cloud:8860/{DATABASE_NAME}?apikey=#######"
```
2. In your database make sure no table `objects` exists. If it does exist drop it. 
3. From the `object-storage-wrapper` repo run `npm start`

## Screenshots & Videos
<img width="1647" alt="Screenshot 2024-09-05 at 4 11 44 PM" src="https://github.com/user-attachments/assets/6fb7d9d7-e75e-4d62-a41b-c9feddd99691">
